### PR TITLE
Added locking on registration/selection.

### DIFF
--- a/src/main/java/xyz/gianlu/zeroconf/ABLock.java
+++ b/src/main/java/xyz/gianlu/zeroconf/ABLock.java
@@ -1,0 +1,197 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 erhannis.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package xyz.gianlu.zeroconf;
+
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import sun.awt.Mutex;
+
+/**
+ * Multistage lock customized for NIO Selectors.<br/>
+ * Extended rationale:<br/>
+ * See, NIO Selectors take locks on their things when they select(), and don't
+ * release them while waiting.  If a select happens before any channels are
+ * registered, the select never completes.  If a register first calls wakeup
+ * to abort the hung select, there's a small chance the select could loop back
+ * around again before the register actually got called.  Adding a plain
+ * synchronization around the two calls doesn't fix it, because if the wakeup
+ * is inside the sync it won't get called and the select won't return, and if
+ * it's outside then the loop-around could still happen and nothing's been
+ * fixed.<br/>
+ * <br/>
+ * So, here's my solution.  Consider the following code.<br/>
+ * <pre>
+ * private final ABLock selectorLock = new ABLock();
+ * 
+ * ...
+ * 
+ * // Channel registration
+ * selectorLock.lockA1();
+ * try {
+ *   getSelector().wakeup();
+ *   selectorLock.lockA2();
+ *   try {
+ *     channels.put(nic, channel.register(getSelector(), SelectionKey.OP_READ));
+ *   } finally {
+ *     selectorLock.unlockA2();
+ *   }
+ * } finally {
+ *   selectorLock.unlockA1();
+ * }
+ *
+ * ...
+ * 
+ * // Select
+ * Selector selector = getSelector();
+ * selectorLock.lockB();
+ * try {
+ *   selector.select();
+ * } finally {
+ *   selectorLock.unlockB();
+ * }
+ * </pre>
+ * <br/>
+ * The goal is to prevent reentering `select` between a `wakeup` and `register`.
+ * To that end:<br/>
+ * B blocks A2.<br/>
+ * A1 blocks B.<br/>
+ * A2 blocks B.<br/>
+ * Nothing else blocks anything else.<br/>
+ * By e.g. "A2 blocks B", I mean "if a lock exists on A2, attempts to acquire a
+ * lock on B will block until there are no more locks on A2."  So, in the
+ * registration thread, you acquire A1 to prevent any new B locks, call wakeup
+ * to get the Selector to drop its B lock, then lock on A2 to wait for it to do
+ * so, then make your registration, then drop the locks (in reverse order, as is
+ * custom).  On the select thread, you acquire B, then select, then release B.<br/>
+ * Unless I've made a goof:<br/>
+ * You can have multiple registrations occur at once, and multiple selections
+ * occur at once, but never both registrations and selections, and a
+ * (lock for a) registration will not wait forever for a selection to conclude.<br/>
+ * HOWEVER.<br/>
+ * I've only tested this briefly.  I'd want to test it a lot more before I was
+ * very comfortable with it, and I don't really have time right now.  I suspect
+ * it's better than nothing, at least, though.
+ * 
+ * @author erhannis
+ */
+public class ABLock {
+  private long a1 = 0;
+  private long a2 = 0;
+  private long b = 0;
+  
+  private final Object sync = new Object();
+  
+  /**
+   * For every call to lockA1, there must be exactly one subsequent call to unlockA1.<br/>
+   * Attempted locks on A1 are not blocked by anything.
+   * An existing lock on A1 blocks new locks on B.
+   * An existing lock on A1 DOES NOT block new locks on A1 or A2.
+   */
+  public void lockA1() {
+    synchronized (sync) {
+      a1++;
+      sync.notifyAll();
+    }
+  }
+  
+  public void unlockA1() {
+    synchronized (sync) {
+      a1--;
+      sync.notifyAll();
+    }
+  }
+  
+  /**
+   * For every call to lockA2, there must be a subsequent call to unlockA2.<br/>
+   * Attempted locks on A2 are blocked by existing locks on B, and nothing else.
+   * An existing lock on A2 blocks new locks on B.
+   * An existing lock on A2 DOES NOT block new locks on A1 or A2.
+   */
+  public void lockA2() {
+    synchronized (sync) {
+      while (b > 0) {
+        try {
+          sync.wait();
+        } catch (InterruptedException ex) {}
+      }
+      a2++;
+      sync.notifyAll();
+    }
+  }
+
+  public void lockA2interruptible() throws InterruptedException {
+    synchronized (sync) {
+      while (b > 0) {
+        sync.wait();
+      }
+      a2++;
+      sync.notifyAll();
+    }
+  }
+  
+  public void unlockA2() {
+    synchronized (sync) {
+      a2--;
+      sync.notifyAll();
+    }
+  }
+  
+  /**
+   * For every call to lockB, there must be a subsequent call to unlockB.<br/>
+   * Attempted locks on B are blocked by existing locks on A1 and A2, and nothing else.
+   * An existing lock on B blocks new locks on A2.
+   * An existing lock on B DOES NOT block new locks on A1 or B.
+   */
+  public void lockB() {
+    synchronized (sync) {
+      while (a1 > 0 || a2 > 0) {
+        try {
+          sync.wait();
+        } catch (InterruptedException ex) {}
+      }
+      b++;
+      sync.notifyAll();
+    }
+  }
+  
+  public void lockBinterruptible() throws InterruptedException {
+    synchronized (sync) {
+      while (a1 > 0 || a2 > 0) {
+        sync.wait();
+      }
+      b++;
+      sync.notifyAll();
+    }
+  }
+
+  public void unlockB() {
+    synchronized (sync) {
+      b--;
+      sync.notifyAll();
+    }
+  }
+}

--- a/src/main/java/xyz/gianlu/zeroconf/ABLock.java
+++ b/src/main/java/xyz/gianlu/zeroconf/ABLock.java
@@ -110,16 +110,6 @@ public final class ABLock {
         }
     }
 
-    public void lockA1Interruptable() throws InterruptedException {
-        synchronized (sync) {
-            while (b > 0)
-                sync.wait();
-
-            a1++;
-            sync.notifyAll();
-        }
-    }
-
     public void unlockA1() {
         synchronized (sync) {
             a1--;
@@ -143,16 +133,6 @@ public final class ABLock {
         }
     }
 
-    public void lockA2Interruptable() throws InterruptedException {
-        synchronized (sync) {
-            while (b > 0)
-                sync.wait();
-
-            a2++;
-            sync.notifyAll();
-        }
-    }
-
     public void unlockA2() {
         synchronized (sync) {
             a2--;
@@ -167,16 +147,6 @@ public final class ABLock {
      * An existing lock on B DOES NOT block new locks on A1 or B.
      */
     public void lockB() throws InterruptedException {
-        synchronized (sync) {
-            while (a1 > 0 || a2 > 0)
-                sync.wait();
-
-            b++;
-            sync.notifyAll();
-        }
-    }
-
-    public void lockBInterruptable() throws InterruptedException {
         synchronized (sync) {
             while (a1 > 0 || a2 > 0)
                 sync.wait();

--- a/src/main/java/xyz/gianlu/zeroconf/Zeroconf.java
+++ b/src/main/java/xyz/gianlu/zeroconf/Zeroconf.java
@@ -507,8 +507,8 @@ public final class Zeroconf implements Closeable {
         private final Deque<Packet> sendq;
         private final Map<NetworkInterface, SelectionKey> channels;
         private final Map<NetworkInterface, List<InetAddress>> localAddresses;
-        private volatile boolean cancelled;
         private final ABLock selectorLock = new ABLock();
+        private volatile boolean cancelled;
         private Selector selector;
 
         ListenerThread() {
@@ -521,7 +521,8 @@ public final class Zeroconf implements Closeable {
         }
 
         private synchronized Selector getSelector() throws IOException {
-            if (selector == null) selector = Selector.open(); //TODO Is this expensive?  Setting `selector` `final` and initializing on creation would remove the need for a synchronized `getSelector` method.
+            if (selector == null)
+                selector = Selector.open(); // TODO: Is this expensive?  Setting `selector` `final` and initializing on creation would remove the need for a synchronized `getSelector` method.
             return selector;
         }
 
@@ -589,16 +590,19 @@ public final class Zeroconf implements Closeable {
 
                 selectorLock.lockA1();
                 try {
-                  getSelector().wakeup();
-                  selectorLock.lockA2();
-                  try {
-                    channels.put(nic, channel.register(getSelector(), SelectionKey.OP_READ));
-                  } finally {
-                    selectorLock.unlockA2();
-                  }
+                    getSelector().wakeup();
+
+                    selectorLock.lockA2();
+                    try {
+                        channels.put(nic, channel.register(getSelector(), SelectionKey.OP_READ));
+                    } finally {
+                        selectorLock.unlockA2();
+                    }
+                } catch (InterruptedException ignored) {
                 } finally {
-                  selectorLock.unlockA1();
+                    selectorLock.unlockA1();
                 }
+
                 localAddresses.put(nic, locallist);
                 if (!isAlive()) start();
             }
@@ -657,10 +661,11 @@ public final class Zeroconf implements Closeable {
                     Selector selector = getSelector();
                     selectorLock.lockB();
                     try {
-                      selector.select();
+                        selector.select();
                     } finally {
-                      selectorLock.unlockB();
+                        selectorLock.unlockB();
                     }
+
                     Set<SelectionKey> selected = selector.selectedKeys();
                     for (SelectionKey key : selected) {
                         // We know selected keys are readable


### PR DESCRIPTION
It's too complicated for its own good, though, and I'm not super confident it doesn't have bugs.  It worked the few times I tested it, though, and fixed the problem I'd been having, so things seem better now than they were, at least.

The existing fix reduced the problem, but I believe still had a race condition.  This one _might_ be perfect, or _might_ be worse.  Kindof up to you whether you want to use it or not.  I'd test it more - but I have other things I've gotta do.

Also, btw, I synchronized the getSelector() call, because that's another race condition that could bork things up once in a while.  If the performance hit is concerning, consider whether it could just set the selector on initialization and forego the getSelector method entirely.