### PR TITLE
Update sample code to fix issue #6

### DIFF
--- a/src/main/java/xyz/gianlu/zeroconf/Main.java
+++ b/src/main/java/xyz/gianlu/zeroconf/Main.java
@@ -9,8 +9,8 @@ public class Main {
     public static void main(String[] args) throws IOException {
         Zeroconf zeroconf = new Zeroconf();
         zeroconf.setUseIpv4(true)
-                .setUseIpv6(false);
-                .addAllNetworkInterfaces()
+                .setUseIpv6(false)
+                .addAllNetworkInterfaces();
 
         Runtime.getRuntime().addShutdownHook(new Thread(zeroconf::close));
 

--- a/src/main/java/xyz/gianlu/zeroconf/Main.java
+++ b/src/main/java/xyz/gianlu/zeroconf/Main.java
@@ -8,9 +8,9 @@ import java.io.IOException;
 public class Main {
     public static void main(String[] args) throws IOException {
         Zeroconf zeroconf = new Zeroconf();
-        zeroconf.addAllNetworkInterfaces()
-                .setUseIpv4(true)
+        zeroconf.setUseIpv4(true)
                 .setUseIpv6(false);
+                .addAllNetworkInterfaces()
 
         Runtime.getRuntime().addShutdownHook(new Thread(zeroconf::close));
 


### PR DESCRIPTION
The code used in `Main.java` results in the following error on my machine, but the solution mentioned in #6 seems to fix it. Thought `Main.java` should be updated to reflect the solution.

```kotlin
Exception in thread "IO, pool-1-thread-1" java.nio.channels.UnsupportedAddressTypeException
	at java.base/sun.nio.ch.Net.checkAddress(Net.java:142)
	at java.base/sun.nio.ch.DatagramChannelImpl.bindInternal(DatagramChannelImpl.java:808)
	at java.base/sun.nio.ch.DatagramChannelImpl.bind(DatagramChannelImpl.java:785)
	at xyz.gianlu.zeroconf.Zeroconf$ListenerThread.addNetworkInterface(Zeroconf.java:700)
	at xyz.gianlu.zeroconf.Zeroconf.addNetworkInterface(Zeroconf.java:199)
	at xyz.gianlu.zeroconf.Zeroconf.addAllNetworkInterfaces(Zeroconf.java:238)
	at me.saket.teleport.transfer.RealNetworkDiscoverer$announceAndDiscover$$inlined$observable$1.subscribe(Various.kt:118)
	at me.saket.teleport.transfer.RealNetworkDiscoverer$announceAndDiscover$$inlined$observable$1.subscribe(Various.kt:11)
	at com.badoo.reaktive.base.SubscribeSafeKt.subscribeSafe(SubscribeSafe.kt:7)
	at com.badoo.reaktive.observable.SubscribeOnKt$subscribeOn$$inlined$observable$1$lambda$1.invoke(SubscribeOn.kt:17)
	at com.badoo.reaktive.observable.SubscribeOnKt$subscribeOn$$inlined$observable$1$lambda$1.invoke(SubscribeOn.kt)
	at com.badoo.reaktive.scheduler.ExecutorServiceScheduler$ExecutorImpl$Companion$wrapSchedulerTaskSafe$1.run(ExecutorServiceScheduler.kt:102)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```